### PR TITLE
Relaxed bytestring version constraint

### DIFF
--- a/monadcryptorandom.cabal
+++ b/monadcryptorandom.cabal
@@ -1,5 +1,5 @@
 name:           monadcryptorandom
-version:        0.5
+version:        0.5.0.1
 license:        BSD3
 license-file:   LICENSE
 copyright:      Thomas DuBuisson <thomas.dubuisson@gmail.com>
@@ -19,7 +19,7 @@ extra-source-files:
 
 Library
   Build-Depends: base == 4.*,
-                 bytestring >= 0.9 && < 0.10,
+                 bytestring >= 0.9 && < 0.11,
                  mtl >= 2.0, crypto-api >= 0.2, transformers >= 0.2,
                  tagged >= 0.2
   ghc-options:


### PR DESCRIPTION
Now Compiles on GHC 7.6 with the newest versions of the packages.
