### PR TITLE
Added instances for `mtl` types.

### DIFF
--- a/Control/Monad/CryptoRandom.hs
+++ b/Control/Monad/CryptoRandom.hs
@@ -373,6 +373,34 @@ instance (ContainsGenError e, Error e, Monad m, CryptoRandomGen g) => MonadCRand
   getCRandomR = wrap . crandomR
   {-# INLINE getCRandomR #-}
 
+instance MonadCRandomR e m => MonadCRandomR e (Lazy.StateT s m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
+instance MonadCRandomR e m => MonadCRandomR e (Strict.StateT s m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
+instance (MonadCRandomR e m, Monoid w) => MonadCRandomR e (Lazy.WriterT w m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
+instance (MonadCRandomR e m, Monoid w) => MonadCRandomR e (Strict.WriterT w m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
+instance MonadCRandomR e m => MonadCRandomR e (ReaderT r m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
+instance (MonadCRandomR e m, Monoid w) => MonadCRandomR e (Lazy.RWST r w s m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
+instance (MonadCRandomR e m, Monoid w) => MonadCRandomR e (Strict.RWST r w s m) where
+  getCRandomR = lift . getCRandomR
+  {-# INLINE getCRandomR #-}
+
 instance Error GenError where
   noMsg = GenErrorOther "noMsg"
   strMsg = GenErrorOther


### PR DESCRIPTION
We've had a user `fragramus` on the Haskell channel for the last couple of days armwrestling with transformer stacks because he put `CRandT` on the bottom of the stack, so I figured I'd just fix the issue at the source.

This patch adds a `MonadState` instance to `CRandT`.

You may want to consider also lifting `MonadWriter`, etc. 

The instances are remarkably straightforward.

[Edit: I actually did the rest of them too]
