### PR TITLE
Control/Monad/CryptoRandom.hs: import Data.Tagged to fix the build with tagged 0.7

### DIFF
--- a/Control/Monad/CryptoRandom.hs
+++ b/Control/Monad/CryptoRandom.hs
@@ -47,6 +47,7 @@ import Data.Int
 import Data.List (foldl')
 import Data.Word
 import Data.Proxy
+import Data.Tagged
 import qualified Data.ByteString as B
 
 -- |@MonadCRandom m@ represents a monad that can produce


### PR DESCRIPTION
The Data.Proxy module used to export the 'proxy' function, but in tagged
version 0.7 this function is available only after importing Data.Tagged.
Apparently, this change in tagged is necessary to prepare for the
upcoming GHC 7.7, which is going to ship Data.Proxy as part of base.
